### PR TITLE
Support plugins.txt by setting

### DIFF
--- a/src/gamestarfield.cpp
+++ b/src/gamestarfield.cpp
@@ -147,7 +147,7 @@ QString GameStarfield::description() const
 
 MOBase::VersionInfo GameStarfield::version() const
 {
-  return VersionInfo(0, 0, 1, VersionInfo::RELEASE_PREALPHA);
+  return VersionInfo(0, 5, 0, VersionInfo::RELEASE_BETA);
 }
 
 QList<PluginSetting> GameStarfield::settings() const
@@ -155,7 +155,8 @@ QList<PluginSetting> GameStarfield::settings() const
   return QList<PluginSetting>()
          << PluginSetting("enable_plugin_management",
                           tr("Turn on plugin management. As of Starfield 1.7.33 this "
-                             "REQUIRES SPECIAL WORKAROUNDS."),
+                             "REQUIRES fixing 'plugins.txt' with a SFSE plugin. This "
+                             "will do nothing otherwise."),
                           false);
 }
 

--- a/src/gamestarfield.cpp
+++ b/src/gamestarfield.cpp
@@ -152,7 +152,24 @@ MOBase::VersionInfo GameStarfield::version() const
 
 QList<PluginSetting> GameStarfield::settings() const
 {
-  return QList<PluginSetting>();
+  return QList<PluginSetting>()
+         << PluginSetting("enable_plugin_management",
+                          tr("Turn on plugin management. As of Starfield 1.7.33 this "
+                             "REQUIRES SPECIAL WORKAROUNDS."),
+                          false);
+}
+
+MappingType GameStarfield::mappings() const
+{
+  MappingType result;
+  if (m_Organizer->pluginSetting(name(), "enable_plugin_management").toBool()) {
+    for (const QString& profileFile : {"plugins.txt", "loadorder.txt"}) {
+      result.push_back({m_Organizer->profilePath() + "/" + profileFile,
+                        localAppFolder() + "/" + gameShortName() + "/" + profileFile,
+                        false});
+    }
+  }
+  return result;
 }
 
 void GameStarfield::initializeProfile(const QDir& path, ProfileSettings settings) const
@@ -280,6 +297,9 @@ IPluginGame::SortMechanism GameStarfield::sortMechanism() const
 
 IPluginGame::LoadOrderMechanism GameStarfield::loadOrderMechanism() const
 {
+  if (m_Organizer->pluginSetting(name(), "enable_plugin_management").toBool()) {
+    return IPluginGame::LoadOrderMechanism::PluginsTxt;
+  }
   return IPluginGame::LoadOrderMechanism::None;
 }
 

--- a/src/gamestarfield.h
+++ b/src/gamestarfield.h
@@ -48,6 +48,7 @@ public:  // IPlugin interface
   virtual QString description() const override;
   virtual MOBase::VersionInfo version() const override;
   virtual QList<MOBase::PluginSetting> settings() const override;
+  virtual MappingType mappings() const override;
 
 protected:
   virtual QString identifyGamePath() const override;

--- a/src/starfieldgameplugins.cpp
+++ b/src/starfieldgameplugins.cpp
@@ -10,3 +10,14 @@ bool StarfieldGamePlugins::overridePluginsAreSupported()
 {
   return true;
 }
+
+void StarfieldGamePlugins::writePluginList(const IPluginList* pluginList,
+                                           const QString& filePath)
+{
+  if (m_Organizer
+          ->pluginSetting(m_Organizer->managedGame()->name(),
+                          "enable_plugin_management")
+          .toBool()) {
+    CreationGamePlugins::writePluginList(pluginList, filePath);
+  }
+}

--- a/src/starfieldgameplugins.h
+++ b/src/starfieldgameplugins.h
@@ -14,6 +14,8 @@ public:
 
 protected:
   virtual bool overridePluginsAreSupported() override;
+  virtual void writePluginList(const MOBase::IPluginList* pluginList,
+                               const QString& filePath) override;
 };
 
 #endif  // _STARFIELDGAMEPLUGINS_H


### PR DESCRIPTION
- SFSE plugin adds plugins.txt support
- Allow advanced users to enable this in the plugin settings
- Fully disable writing to the plugins.txt file if disabled
- Fully disable mapping the plugins.txt if disabled