### PR TITLE
Plugin sorting updates

### DIFF
--- a/src/gamestarfield.h
+++ b/src/gamestarfield.h
@@ -17,6 +17,9 @@ public:
 
   virtual bool init(MOBase::IOrganizer* moInfo) override;
 
+public:
+  QStringList testFilePlugins() const;
+
 public:  // IPluginGame interface
   virtual QString gameName() const override;
   virtual void detectGame() override;
@@ -29,6 +32,7 @@ public:  // IPluginGame interface
                                  ProfileSettings settings) const override;
   virtual QString steamAPPId() const override;
   virtual QStringList primaryPlugins() const override;
+  virtual QStringList enabledPlugins() const override;
   virtual QStringList gameVariants() const override;
   virtual QString gameShortName() const override;
   virtual QString gameNexusName() const override;

--- a/src/starfieldgameplugins.cpp
+++ b/src/starfieldgameplugins.cpp
@@ -14,10 +14,8 @@ bool StarfieldGamePlugins::overridePluginsAreSupported()
 void StarfieldGamePlugins::writePluginList(const IPluginList* pluginList,
                                            const QString& filePath)
 {
-  if (m_Organizer
-          ->pluginSetting(m_Organizer->managedGame()->name(),
-                          "enable_plugin_management")
-          .toBool()) {
+  if (m_Organizer->managedGame()->sortMechanism() !=
+      MOBase::IPluginGame::SortMechanism::NONE) {
     CreationGamePlugins::writePluginList(pluginList, filePath);
   }
 }

--- a/src/starfieldgameplugins.cpp
+++ b/src/starfieldgameplugins.cpp
@@ -19,3 +19,12 @@ void StarfieldGamePlugins::writePluginList(const IPluginList* pluginList,
     CreationGamePlugins::writePluginList(pluginList, filePath);
   }
 }
+
+QStringList StarfieldGamePlugins::readPluginList(MOBase::IPluginList* pluginList)
+{
+  if (m_Organizer->managedGame()->sortMechanism() !=
+      MOBase::IPluginGame::SortMechanism::NONE) {
+    return CreationGamePlugins::readPluginList(pluginList);
+  }
+  return {};
+}

--- a/src/starfieldgameplugins.h
+++ b/src/starfieldgameplugins.h
@@ -16,6 +16,7 @@ protected:
   virtual bool overridePluginsAreSupported() override;
   virtual void writePluginList(const MOBase::IPluginList* pluginList,
                                const QString& filePath) override;
+  virtual QStringList readPluginList(MOBase::IPluginList* pluginList) override;
 };
 
 #endif  // _STARFIELDGAMEPLUGINS_H


### PR DESCRIPTION
- Add enabledPlugins for core plugins which are enabled but NOT auto-loaded (may need to be written to plugins.txt or have an ambiguous load order position)
- General Starfield updates
  - Add enabledPlugins for "BlueprintShips-Starfield.esm"
  - Disable plugin management if sTestFile is in use (also applies to FO4)
  - Write the enabledPlugins to plugins.txt to enforce base game load order
  - Allow for LOOT sorting (dynamic based on settings)
- Incorporate enabledPlugins into force enabled plugins in plugin list
- Update various interface layers

TODO: Fix sort button to dynamically update if status changes
TODO: Auto refresh lists if the INI Editor is closed