### PR TITLE
Don't include 'force-enabled' plugins

### DIFF
--- a/src/starfieldunmanagedmods.cpp
+++ b/src/starfieldunmanagedmods.cpp
@@ -10,7 +10,7 @@ QStringList StarfieldUnmangedMods::mods(bool onlyOfficial) const
 {
   QStringList result;
 
-  QStringList pluginList   = game()->primaryPlugins();
+  QStringList pluginList   = game()->primaryPlugins() + game()->enabledPlugins();
   QStringList otherPlugins = game()->DLCPlugins();
   otherPlugins.append(game()->CCPlugins());
   for (QString plugin : otherPlugins) {


### PR DESCRIPTION
I didn't add the 'enabledPlugins' to the list of plugins to exclude from the 'unmanaged mod' list.