### PR TITLE
Fix nexus game ID

### DIFF
--- a/src/gamestarfield.cpp
+++ b/src/gamestarfield.cpp
@@ -299,10 +299,10 @@ IPluginGame::LoadOrderMechanism GameStarfield::loadOrderMechanism() const
 
 int GameStarfield::nexusModOrganizerID() const
 {
-  return 28715;
+  return 0;
 }
 
 int GameStarfield::nexusGameID() const
 {
-  return 1151;
+  return 4187;
 }


### PR DESCRIPTION
This is also necessary to get BSA Packer to work properly.

https://github.com/ModOrganizer2/modorganizer-bsapacker/pull/29