### PR TITLE
Various updates

### DIFF
--- a/src/game_starfield_en.ts
+++ b/src/game_starfield_en.ts
@@ -4,19 +4,106 @@
 <context>
     <name>GameStarfield</name>
     <message>
-        <location filename="gamestarfield.cpp" line="107"/>
+        <location filename="gamestarfield.cpp" line="113"/>
         <source>Starfield Support Plugin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="gamestarfield.cpp" line="117"/>
+        <location filename="gamestarfield.cpp" line="123"/>
         <source>Adds support for the game Starfield.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="gamestarfield.cpp" line="129"/>
-        <source>Turn on plugin management. As of Starfield 1.7.33 this REQUIRES fixing &apos;plugins.txt&apos; with a SFSE plugin. This will do nothing otherwise.</source>
-        <oldsource>Turn on plugin management. As of Starfield 1.7.33 this REQUIRES SPECIAL WORKAROUNDS.</oldsource>
+        <location filename="gamestarfield.cpp" line="136"/>
+        <source>Show a warning when ESP plugins are enabled in the load order.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="gamestarfield.cpp" line="140"/>
+        <source>Show a warning when light plugins are enabled in the load order.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="gamestarfield.cpp" line="143"/>
+        <source>Show a warning when overlay-flagged plugins ar enabled in the load order.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="gamestarfield.cpp" line="147"/>
+        <source>Show a warning when plugins.txt management is invalid.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="gamestarfield.cpp" line="150"/>
+        <source>As of this release LOOT Starfield support is minimal to nonexistant. Toggle this to enable it anyway.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="gamestarfield.cpp" line="444"/>
+        <source>You have active ESP plugins in Starfield</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="gamestarfield.cpp" line="446"/>
+        <source>You have active ESL plugins in Starfield</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="gamestarfield.cpp" line="448"/>
+        <source>You have active overlay plugins</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="gamestarfield.cpp" line="450"/>
+        <source>sTestFile entries are present</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="gamestarfield.cpp" line="452"/>
+        <source>Plugins.txt Enabler missing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="gamestarfield.cpp" line="461"/>
+        <source>&lt;p&gt;ESP plugins are not ideal for Starfield. In addition to being unable to sort them alongside ESM or master-flagged plugins, certain record references are always kept loaded by the game. This consumes unnecessary resources and limits the game&apos;s ability to load what it needs.&lt;/p&gt;&lt;p&gt;Ideally, plugins should be saved as ESM files upon release. It can also be released as an ESL plugin, however there are additional concerns with the way light plugins are currently handled and should only be used when absolutely certain about what you&apos;re doing.&lt;/p&gt;&lt;p&gt;Notably, xEdit does not currently support saving ESP files.&lt;/p&gt;&lt;h4&gt;Current ESPs:&lt;/h4&gt;&lt;p&gt;%1&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="gamestarfield.cpp" line="476"/>
+        <source>&lt;p&gt;Light plugins work differently in Starfield. They use a different base form ID compared with standard plugin files.&lt;/p&gt;&lt;p&gt;What this means is that you can&apos;t just change a standard plugin to a light plugin at will, it can and will break any dependent plugin. If you do so, be absolutely certain no other plugins use that plugin as a master.&lt;/p&gt;&lt;p&gt;Notably, xEdit does not currently support saving or loading ESL files under these conditions.&lt;p&gt;&lt;h4&gt;Current ESLs:&lt;/h4&gt;&lt;p&gt;%1&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="gamestarfield.cpp" line="489"/>
+        <source>&lt;p&gt;Overlay-flagged plugins are not currently recommended. In theory, they should allow you to update existing records without utilizing additional load order slots. Unfortunately, it appears that the game still allocates the slots as if these were standard plugins. Therefore, at the moment there is no real use for this plugin flag.&lt;/p&gt;&lt;p&gt;Notably, xEdit does not currently support saving or loading overlay-flagged files under these conditions.&lt;/p&gt;&lt;h4&gt;Current Overlays:&lt;/h4&gt;&lt;p&gt;%1&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="gamestarfield.cpp" line="500"/>
+        <source>&lt;p&gt;You have plugin managment enabled but you still have sTestFile settings in your StarfieldCustom.ini. These must be removed or the game will not read the plugins.txt file. Management is still disabled.&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="gamestarfield.cpp" line="505"/>
+        <source>&lt;p&gt;You have plugin management turned on but do not have the Plugins.txt Enabler SFSE plugin installed. Plugin file management for Starfield will not work without this SFSE plugin.&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>StarfieldModDataContent</name>
+    <message>
+        <location filename="starfieldmoddatacontent.h" line="29"/>
+        <source>Materials</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="starfieldmoddatacontent.h" line="30"/>
+        <source>Geometries</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="starfieldmoddatacontent.h" line="31"/>
+        <source>Video</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/gamestarfield.h
+++ b/src/gamestarfield.h
@@ -73,7 +73,7 @@ private:
   bool activeESL() const;
   bool activeOverlay() const;
   bool testFilePresent() const;
-  bool pluginsTxtEnabler() const;
+  bool pluginsTxtEnablerPresent() const;
 
 private:
   static const unsigned int PROBLEM_ESP         = 1;

--- a/src/starfielddataarchives.cpp
+++ b/src/starfielddataarchives.cpp
@@ -81,9 +81,9 @@ QStringList StarfieldDataArchives::archives(const MOBase::IProfile* profile) con
                                  "sResourceStartUpArchiveList",
                                  "sResourceEnglishVoiceList"};
   for (auto setting : archiveSettings) {
-    auto archives = getArchivesFromKey(customIniFile, setting, 1023);
+    auto archives = getArchivesFromKey(customIniFile, setting, 4096);
     if (archives.isEmpty())
-      archives = getArchivesFromKey(defaultIniFile, setting, 1023);
+      archives = getArchivesFromKey(defaultIniFile, setting, 4096);
     result.append(archives);
   }
 

--- a/src/starfieldgameplugins.cpp
+++ b/src/starfieldgameplugins.cpp
@@ -14,16 +14,16 @@ bool StarfieldGamePlugins::overridePluginsAreSupported()
 void StarfieldGamePlugins::writePluginList(const IPluginList* pluginList,
                                            const QString& filePath)
 {
-  if (m_Organizer->managedGame()->sortMechanism() !=
-      MOBase::IPluginGame::SortMechanism::NONE) {
+  if (m_Organizer->managedGame()->loadOrderMechanism() ==
+      MOBase::IPluginGame::LoadOrderMechanism::PluginsTxt) {
     CreationGamePlugins::writePluginList(pluginList, filePath);
   }
 }
 
 QStringList StarfieldGamePlugins::readPluginList(MOBase::IPluginList* pluginList)
 {
-  if (m_Organizer->managedGame()->sortMechanism() !=
-      MOBase::IPluginGame::SortMechanism::NONE) {
+  if (m_Organizer->managedGame()->loadOrderMechanism() ==
+      MOBase::IPluginGame::LoadOrderMechanism::PluginsTxt) {
     return CreationGamePlugins::readPluginList(pluginList);
   }
   return {};


### PR DESCRIPTION
- Disable LOOT sorting by default with option to enable
- Update length of INI strings for archive parsing
- Fix issues with plugin list state based on various scenarios
- Allow disabling plugin management checks for diagnoses
- Use active plugin management method to determine when to read/write plugins.txt
- Translation file