### PR TITLE
Add Creation parsing and fix issues

### DIFF
--- a/src/gamestarfield.cpp
+++ b/src/gamestarfield.cpp
@@ -259,8 +259,8 @@ QStringList GameStarfield::primaryPlugins() const
 {
   QStringList plugins = {"Starfield.esm", "Constellation.esm",
                          "OldMars.esm",   "BlueprintShips-Starfield.esm",
-                         "SFBGS003.esm",  "SFBGS006.esm",
-                         "SFBGS007.esm",  "SFBGS008.esm"};
+                         "SFBGS007.esm",  "SFBGS008.esm",
+                         "SFBGS006.esm",  "SFBGS003.esm"};
 
   auto testPlugins = testFilePlugins();
   if (loadOrderMechanism() == LoadOrderMechanism::None) {

--- a/src/gamestarfield.h
+++ b/src/gamestarfield.h
@@ -71,6 +71,7 @@ protected:
 private:
   bool activeESP() const;
   bool testFilePresent() const;
+  void setCCCFile() const;
 
 private:
   static const unsigned int PROBLEM_ESP       = 1;

--- a/src/starfieldunmanagedmods.cpp
+++ b/src/starfieldunmanagedmods.cpp
@@ -1,9 +1,11 @@
 #include "starfieldunmanagedmods.h"
 
+#include "log.h"
+#include "scopeguard.h"
+
 #include <QFile>
 #include <QJsonArray>
 #include <QJsonDocument>
-#include <QJsonObject>
 #include <QJsonValue>
 
 StarfieldUnmangedMods::StarfieldUnmangedMods(const GameStarfield* game,
@@ -53,40 +55,54 @@ QFileInfo StarfieldUnmangedMods::referenceFile(const QString& modName) const
   }
 }
 
-QStringList StarfieldUnmangedMods::secondaryFiles(const QString& modName) const
+QJsonObject StarfieldUnmangedMods::getContentCatalog() const
 {
   QFile content(m_AppDataFolder + "/" + game()->gameShortName() +
                 "/ContentCatalog.txt");
-  QStringList files;
   if (content.exists()) {
     if (content.open(QIODevice::OpenModeFlag::ReadOnly)) {
-      auto contentData         = content.readAll();
-      QJsonDocument contentDoc = QJsonDocument::fromJson(contentData);
-      QJsonObject contentObj   = contentDoc.object();
-      for (auto mod : contentObj.keys()) {
-        if (mod == "ContentCatalog")
-          continue;
-        auto modData  = contentObj.value(mod).toObject();
-        auto modFiles = modData.value("Files").toArray();
-        bool found    = false;
-        for (auto file : modFiles) {
-          if (file.toString().startsWith(modName, Qt::CaseInsensitive)) {
-            found = true;
-          }
-          if (found)
-            break;
-        }
-        if (found) {
-          for (auto file : modFiles) {
-            if (!file.toString().endsWith(".esm") &&
-                !file.toString().endsWith(".esl") && !file.toString().endsWith(".esp"))
-              files.append(file.toString());
-          }
-          break;
-        }
+      ON_BLOCK_EXIT([&content]() {
+        content.close();
+      });
+      auto contentData = content.readAll();
+      QJsonParseError jsonError;
+      QJsonDocument contentDoc = QJsonDocument::fromJson(contentData, &jsonError);
+      if (jsonError.error) {
+        MOBase::log::warn(QObject::tr("ContentCatalog.txt appears to be corrupt: %1")
+                              .arg(jsonError.errorString()));
+      } else {
+        return contentDoc.object();
       }
     }
-    content.close();
+  }
+  return QJsonObject();
+}
+
+QStringList StarfieldUnmangedMods::secondaryFiles(const QString& modName) const
+{
+  QStringList files;
+  QJsonObject contentObj = getContentCatalog();
+  for (auto mod : contentObj.keys()) {
+    if (mod == "ContentCatalog")
+      continue;
+    auto modData  = contentObj.value(mod).toObject();
+    auto modFiles = modData.value("Files").toArray();
+    bool found    = false;
+    for (auto file : modFiles) {
+      if (file.toString().startsWith(modName, Qt::CaseInsensitive)) {
+        found = true;
+      }
+      if (found)
+        break;
+    }
+    if (found) {
+      for (auto file : modFiles) {
+        if (!file.toString().endsWith(".esm") && !file.toString().endsWith(".esl") &&
+            !file.toString().endsWith(".esp"))
+          files.append(file.toString());
+      }
+      break;
+    }
   }
   // file extension in FO4 is .ba2 instead of bsa
   QMap<QString, QDir> directories = {{"data", game()->dataDirectory()}};
@@ -103,32 +119,25 @@ QString StarfieldUnmangedMods::displayName(const QString& modName) const
 {
   QFile content(m_AppDataFolder + "/" + game()->gameShortName() +
                 "/ContentCatalog.txt");
-  QString name = modName;
-  if (content.exists()) {
-    if (content.open(QIODevice::OpenModeFlag::ReadOnly)) {
-      auto contentData         = content.readAll();
-      QJsonDocument contentDoc = QJsonDocument::fromJson(contentData);
-      QJsonObject contentObj   = contentDoc.object();
-      for (auto mod : contentObj.keys()) {
-        if (mod == "ContentCatalog")
-          continue;
-        auto modData  = contentObj.value(mod).toObject();
-        auto modFiles = modData.value("Files").toArray();
-        bool found    = false;
-        for (auto file : modFiles) {
-          if (file.toString().startsWith(modName, Qt::CaseInsensitive)) {
-            found = true;
-          }
-          if (found)
-            break;
-        }
-        if (found) {
-          name = modData.value("Title").toString();
-          break;
-        }
+  QString name           = modName;
+  QJsonObject contentObj = getContentCatalog();
+  for (auto mod : contentObj.keys()) {
+    if (mod == "ContentCatalog")
+      continue;
+    auto modData  = contentObj.value(mod).toObject();
+    auto modFiles = modData.value("Files").toArray();
+    bool found    = false;
+    for (auto file : modFiles) {
+      if (file.toString().startsWith(modName, Qt::CaseInsensitive)) {
+        found = true;
       }
+      if (found)
+        break;
     }
-    content.close();
+    if (found) {
+      name = modData.value("Title").toString();
+      break;
+    }
   }
   // unlike in earlier games, in fallout 4 the file name doesn't correspond to
   // the public name

--- a/src/starfieldunmanagedmods.cpp
+++ b/src/starfieldunmanagedmods.cpp
@@ -1,7 +1,14 @@
 #include "starfieldunmanagedmods.h"
 
-StarfieldUnmangedMods::StarfieldUnmangedMods(const GameGamebryo* game)
-    : GamebryoUnmangedMods(game)
+#include <QFile>
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QJsonValue>
+
+StarfieldUnmangedMods::StarfieldUnmangedMods(const GameStarfield* game,
+                                             const QString appDataFolder)
+    : GamebryoUnmangedMods(game), m_AppDataFolder(appDataFolder)
 {}
 
 StarfieldUnmangedMods::~StarfieldUnmangedMods() {}
@@ -16,11 +23,14 @@ QStringList StarfieldUnmangedMods::mods(bool onlyOfficial) const
   for (QString plugin : otherPlugins) {
     pluginList.removeAll(plugin);
   }
-  QDir dataDir(game()->dataDirectory());
-  for (const QString& fileName : dataDir.entryList({"*.esp", "*.esl", "*.esm"})) {
-    if (!pluginList.contains(fileName, Qt::CaseInsensitive)) {
-      if (!onlyOfficial || pluginList.contains(fileName, Qt::CaseInsensitive)) {
-        result.append(fileName.chopped(4));  // trims the extension off
+  QMap<QString, QDir> directories = {{"data", game()->dataDirectory()}};
+  directories.insert(game()->secondaryDataDirectories());
+  for (QDir directory : directories) {
+    for (const QString& fileName : directory.entryList({"*.esp", "*.esl", "*.esm"})) {
+      if (!pluginList.contains(fileName, Qt::CaseInsensitive)) {
+        if (!onlyOfficial || pluginList.contains(fileName, Qt::CaseInsensitive)) {
+          result.append(fileName.chopped(4));  // trims the extension off
+        }
       }
     }
   }
@@ -28,20 +38,99 @@ QStringList StarfieldUnmangedMods::mods(bool onlyOfficial) const
   return result;
 }
 
+QFileInfo StarfieldUnmangedMods::referenceFile(const QString& modName) const
+{
+  QFileInfoList files;
+  QMap<QString, QDir> directories = {{"data", game()->dataDirectory()}};
+  directories.insert(game()->secondaryDataDirectories());
+  for (QDir directory : directories) {
+    files += directory.entryInfoList(QStringList() << modName + ".es*");
+  }
+  if (files.size() > 0) {
+    return files.at(0);
+  } else {
+    return QFileInfo();
+  }
+}
+
 QStringList StarfieldUnmangedMods::secondaryFiles(const QString& modName) const
 {
-  // file extension in FO4 is .ba2 instead of bsa
-  QStringList archives;
-  QDir dataDir = game()->dataDirectory();
-  for (const QString& archiveName : dataDir.entryList({modName + "*.ba2"})) {
-    archives.append(dataDir.absoluteFilePath(archiveName));
+  QFile content(m_AppDataFolder + "/" + game()->gameShortName() +
+                "/ContentCatalog.txt");
+  QStringList files;
+  if (content.exists()) {
+    if (content.open(QIODevice::OpenModeFlag::ReadOnly)) {
+      auto contentData         = content.readAll();
+      QJsonDocument contentDoc = QJsonDocument::fromJson(contentData);
+      QJsonObject contentObj   = contentDoc.object();
+      for (auto mod : contentObj.keys()) {
+        if (mod == "ContentCatalog")
+          continue;
+        auto modData  = contentObj.value(mod).toObject();
+        auto modFiles = modData.value("Files").toArray();
+        bool found    = false;
+        for (auto file : modFiles) {
+          if (file.toString().startsWith(modName, Qt::CaseInsensitive)) {
+            found = true;
+          }
+          if (found)
+            break;
+        }
+        if (found) {
+          for (auto file : modFiles) {
+            if (!file.toString().endsWith(".esm") &&
+                !file.toString().endsWith(".esl") && !file.toString().endsWith(".esp"))
+              files.append(file.toString());
+          }
+          break;
+        }
+      }
+    }
+    content.close();
   }
-  return archives;
+  // file extension in FO4 is .ba2 instead of bsa
+  QMap<QString, QDir> directories = {{"data", game()->dataDirectory()}};
+  directories.insert(game()->secondaryDataDirectories());
+  for (QDir directory : directories) {
+    for (const QString& archiveName : directory.entryList({modName + "*.ba2"})) {
+      files.append(directory.absoluteFilePath(archiveName));
+    }
+  }
+  return files;
 }
 
 QString StarfieldUnmangedMods::displayName(const QString& modName) const
 {
+  QFile content(m_AppDataFolder + "/" + game()->gameShortName() +
+                "/ContentCatalog.txt");
+  QString name = modName;
+  if (content.exists()) {
+    if (content.open(QIODevice::OpenModeFlag::ReadOnly)) {
+      auto contentData         = content.readAll();
+      QJsonDocument contentDoc = QJsonDocument::fromJson(contentData);
+      QJsonObject contentObj   = contentDoc.object();
+      for (auto mod : contentObj.keys()) {
+        if (mod == "ContentCatalog")
+          continue;
+        auto modData  = contentObj.value(mod).toObject();
+        auto modFiles = modData.value("Files").toArray();
+        bool found    = false;
+        for (auto file : modFiles) {
+          if (file.toString().startsWith(modName, Qt::CaseInsensitive)) {
+            found = true;
+          }
+          if (found)
+            break;
+        }
+        if (found) {
+          name = modData.value("Title").toString();
+          break;
+        }
+      }
+    }
+    content.close();
+  }
   // unlike in earlier games, in fallout 4 the file name doesn't correspond to
   // the public name
-  return modName;
+  return name;
 }

--- a/src/starfieldunmanagedmods.h
+++ b/src/starfieldunmanagedmods.h
@@ -2,17 +2,22 @@
 #define STARFIELDUNMANAGEDMODS_H
 
 #include "gamebryounmanagedmods.h"
+#include "gamestarfield.h"
 #include <gamegamebryo.h>
 
 class StarfieldUnmangedMods : public GamebryoUnmangedMods
 {
 public:
-  StarfieldUnmangedMods(const GameGamebryo* game);
+  StarfieldUnmangedMods(const GameStarfield* game, const QString appDataFolder);
   ~StarfieldUnmangedMods();
 
   virtual QStringList mods(bool onlyOfficial) const override;
+  virtual QFileInfo referenceFile(const QString& modName) const override;
   virtual QStringList secondaryFiles(const QString& modName) const override;
   virtual QString displayName(const QString& modName) const override;
+
+private:
+  QString m_AppDataFolder;
 };
 
 #endif  // STARFIELDUNMANAGEDMODS_H

--- a/src/starfieldunmanagedmods.h
+++ b/src/starfieldunmanagedmods.h
@@ -5,6 +5,8 @@
 #include "gamestarfield.h"
 #include <gamegamebryo.h>
 
+#include <QJsonObject>
+
 class StarfieldUnmangedMods : public GamebryoUnmangedMods
 {
 public:
@@ -15,6 +17,9 @@ public:
   virtual QFileInfo referenceFile(const QString& modName) const override;
   virtual QStringList secondaryFiles(const QString& modName) const override;
   virtual QString displayName(const QString& modName) const override;
+
+private:
+  QJsonObject getContentCatalog() const;
 
 private:
   QString m_AppDataFolder;

--- a/src/starfieldunmanagedmods.h
+++ b/src/starfieldunmanagedmods.h
@@ -7,11 +7,19 @@
 
 #include <QJsonObject>
 
-class StarfieldUnmangedMods : public GamebryoUnmangedMods
+class StarfieldUnmanagedMods : public GamebryoUnmangedMods
 {
+  friend class GameStarfield;
+
+  struct ContentCatalog
+  {
+    QString name;
+    QStringList files;
+  };
+
 public:
-  StarfieldUnmangedMods(const GameStarfield* game, const QString appDataFolder);
-  ~StarfieldUnmangedMods();
+  StarfieldUnmanagedMods(const GameStarfield* game, const QString& appDataFolder);
+  ~StarfieldUnmanagedMods();
 
   virtual QStringList mods(bool onlyOfficial) const override;
   virtual QFileInfo referenceFile(const QString& modName) const override;
@@ -19,7 +27,7 @@ public:
   virtual QString displayName(const QString& modName) const override;
 
 private:
-  QJsonObject getContentCatalog() const;
+  std::map<QString, ContentCatalog> parseContentCatalog() const;
 
 private:
   QString m_AppDataFolder;


### PR DESCRIPTION
- Read creations from LocalAppData
- Don't include CC files in primary plugins
- Don't parse CCC file if sTestFile set
- Fix parsing of secondary data directories

TODO: Consolidate ContentCatalog.txt parsing somewhat?