### PR TITLE
Add support for the vehicle update

### DIFF
--- a/src/game_starfield_en.ts
+++ b/src/game_starfield_en.ts
@@ -29,22 +29,22 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="gamestarfield.cpp" line="428"/>
+        <location filename="gamestarfield.cpp" line="429"/>
         <source>You have active ESP plugins in Starfield</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="gamestarfield.cpp" line="430"/>
+        <location filename="gamestarfield.cpp" line="431"/>
         <source>sTestFile entries are present</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="gamestarfield.cpp" line="440"/>
+        <location filename="gamestarfield.cpp" line="441"/>
         <source>&lt;p&gt;ESP plugins are not ideal for Starfield. In addition to being unable to sort them alongside ESM or master-flagged plugins, certain record references are always kept loaded by the game. This consumes unnecessary resources and limits the game&apos;s ability to load what it needs.&lt;/p&gt;&lt;p&gt;Ideally, plugins should be saved as ESM files upon release. It can also be released as an ESL plugin, however there are additional concerns with the way light plugins are currently handled and should only be used when absolutely certain about what you&apos;re doing.&lt;/p&gt;&lt;p&gt;Notably, xEdit does not currently support saving ESP files.&lt;/p&gt;&lt;h4&gt;Current ESPs:&lt;/h4&gt;&lt;p&gt;%1&lt;/p&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="gamestarfield.cpp" line="454"/>
+        <location filename="gamestarfield.cpp" line="455"/>
         <source>&lt;p&gt;You have plugin managment enabled but you still have sTestFile settings in your StarfieldCustom.ini. These must be removed or the game will not read the plugins.txt file. Management is still disabled.&lt;/p&gt;</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/gamestarfield.cpp
+++ b/src/gamestarfield.cpp
@@ -258,7 +258,8 @@ QStringList GameStarfield::primaryPlugins() const
   QStringList plugins = {"Starfield.esm", "Constellation.esm",
                          "OldMars.esm",   "BlueprintShips-Starfield.esm",
                          "SFBGS007.esm",  "SFBGS008.esm",
-                         "SFBGS006.esm",  "SFBGS003.esm"};
+                         "SFBGS006.esm",  "SFBGS003.esm",
+                         "SFBGS004.esm"};
 
   auto testPlugins = testFilePlugins();
   if (loadOrderMechanism() == LoadOrderMechanism::None) {

--- a/src/starfieldsavegame.cpp
+++ b/src/starfieldsavegame.cpp
@@ -104,7 +104,11 @@ std::unique_ptr<GamebryoSaveGame::DataFields> StarfieldSaveGame::fetchDataFields
                            dummyLocation, dummyTime);
   }
 
-  bool extraInfo          = saveVersion >= 122;
+  int extraInfo = 0;
+  if (saveVersion >= 122)
+    extraInfo = 1;
+  if (saveVersion >= 140)
+    extraInfo = 2;
   QStringList gamePlugins = m_Game->primaryPlugins() + m_Game->enabledPlugins();
 
   QString ignore;


### PR DESCRIPTION
- New save format (v140) which adds another plugin list flag for 'is custom plugin'; remaining changes are compatible with existing parser
- New core plugin (SFBGS004.esm)