### PR TITLE
Handle IPluginGame::CONFIGURATION flag and use forward slash for QFile

### DIFF
--- a/src/gamestarfield.cpp
+++ b/src/gamestarfield.cpp
@@ -281,7 +281,7 @@ QStringList GameStarfield::CCCPlugins() const
   // force-loading the core game plugins.
   QStringList plugins = {};
   if (!testFilePresent()) {
-    QFile myDocsCCCFile(myGamesPath() + "\Starfield.ccc");
+    QFile myDocsCCCFile(myGamesPath() + "/Starfield.ccc");
     QFile gameCCCFile(gameDirectory().absoluteFilePath("Starfield.ccc"));
     QFile* file;
     if (myDocsCCCFile.exists()) {

--- a/src/gamestarfield.cpp
+++ b/src/gamestarfield.cpp
@@ -160,6 +160,9 @@ void GameStarfield::initializeProfile(const QDir& path, ProfileSettings settings
 {
   if (settings.testFlag(IPluginGame::MODS)) {
     copyToProfile(localAppFolder() + "/Starfield", path, "plugins.txt");
+  }
+
+  if (settings.testFlag(IPluginGame::CONFIGURATION)) {
     copyToProfile(myGamesPath(), path, "StarfieldPrefs.ini");
     copyToProfile(myGamesPath(), path, "StarfieldCustom.ini");
   }


### PR DESCRIPTION
This adds back the handling of IPluginGame::CONFIGURATION in initializeProfile. This addresses an issue that happens when disabling profile-specific INIs, deleting files, and re-enabling the setting before closing the dialog.

It also changes to a forward slash in the constructor of a QFile.